### PR TITLE
WIP & BUGGY: WebUI: Add additional keyboard handlers (e.g. Insert, Delete, Edit...)

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1615,8 +1615,8 @@ tvheadend.idnode_grid = function(panel, conf)
                 alt: true,
                 stopEvent: true,
                 fn: function() {
-					// This shifts focus to the text box (i.e. the x in "Page x of y")
-					// Feels like a hack
+                    // This shifts focus to the text box (i.e. the x in "Page x of y")
+                    // Feels like a hack
                     page.items.items[4].focus(true);
                     }
             } , {
@@ -1625,8 +1625,8 @@ tvheadend.idnode_grid = function(panel, conf)
                 fn: function() {
                     console.log("EDIT (F2) pressed from ", gconf.stateId);
                     if (grid && abuttons.edit) {
-						// Edit button will be scoped in if a row is selected, so we should
-						// always be good here without a check
+                        // Edit button will be scoped in if a row is selected, so we should
+                        // always be good here without a check
                         abuttons.edit.handler();
                         }
                     }
@@ -1638,8 +1638,8 @@ tvheadend.idnode_grid = function(panel, conf)
                 fn: function() {
                     console.log("EDIT (ctrl+e) pressed from ", gconf.stateId);
                     if (grid && abuttons.edit) {
-						// Edit button will be scoped in if a row is selected, so we should
-						// always be good here without a check
+                        // Edit button will be scoped in if a row is selected, so we should
+                        // always be good here without a check
                         abuttons.edit.handler();
                         }
                     }
@@ -1650,11 +1650,11 @@ tvheadend.idnode_grid = function(panel, conf)
                 fn: function() {
                     console.log("SAVE (ctrl+s) pressed from ", gconf.stateId);
                     if (grid && abuttons.save) {
-						// Check that we have a Save button before triggering
-						// Saves on a 404 AJAX error when we save an unchanged store
-						// This simply relies on the store to know if it's been changed,
-						// which is what scopes in the Undo button anyway.                        
-						if (!abuttons.save.disabled) abuttons.save.handler();
+                        // Check that we have a Save button before triggering
+                        // Saves on a 404 AJAX error when we save an unchanged store
+                        // This simply relies on the store to know if it's been changed,
+                        // which is what scopes in the Undo button anyway.                        
+                        if (!abuttons.save.disabled) abuttons.save.handler();
                         }
                     }
             } , {
@@ -1664,10 +1664,10 @@ tvheadend.idnode_grid = function(panel, conf)
                 fn: function() {
                     console.log("UNDO (ctrl+z) pressed from ", gconf.stateId);
                     if (grid && abuttons.undo) {
-						// Check that we have an Undo button before triggering
-						// Saves on a 404 AJAX error when we save an unchanged store
-						// As 'Save', this simply relies on the store to know if it's been changed,
-						// which is what scopes in the Undo button anyway.
+                        // Check that we have an Undo button before triggering
+                        // Saves on a 404 AJAX error when we save an unchanged store
+                        // As 'Save', this simply relies on the store to know if it's been changed,
+                        // which is what scopes in the Undo button anyway.
                         if (!abuttons.undo.disabled) abuttons.undo.handler();
                         }
                     }

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1598,6 +1598,98 @@ tvheadend.idnode_grid = function(panel, conf)
         }
 
         plugins.push(filter);
+
+        var keymap = new Ext.KeyMap(Ext.getDoc(), [
+            {
+                key: 'a',
+                ctrl: true,
+                stopEvent: true,
+                fn: function() { 
+                    grid.getSelectionModel().selectAll();
+                    }
+            } , {
+// Shift focus to the paging toolbar so we can use the built-in handlers
+// (PagingToolbar.js) for Home, End, PgUp, PgDn and not interfere with the
+// "within page" scrolling
+                key: 'p',
+                alt: true,
+                stopEvent: true,
+                fn: function() {
+					// This shifts focus to the text box (i.e. the x in "Page x of y")
+					// Feels like a hack
+                    page.items.items[4].focus(true);
+                    }
+            } , {
+                key: [Ext.EventObject.F2],
+                stopEvent: true,
+                fn: function() {
+                    console.log("EDIT (F2) pressed from ", gconf.stateId);
+                    if (grid && abuttons.edit) {
+						// Edit button will be scoped in if a row is selected, so we should
+						// always be good here without a check
+                        abuttons.edit.handler();
+                        }
+                    }
+            } , {
+                // Second handler for Edit - you can't seem to mix modified (ctrl+) and unmodified keys
+                key: 'e',
+                ctrl: true,
+                stopEvent: true,
+                fn: function() {
+                    console.log("EDIT (ctrl+e) pressed from ", gconf.stateId);
+                    if (grid && abuttons.edit) {
+						// Edit button will be scoped in if a row is selected, so we should
+						// always be good here without a check
+                        abuttons.edit.handler();
+                        }
+                    }
+            } , {
+                key: 's',
+                ctrl: true,
+                stopEvent: true,
+                fn: function() {
+                    console.log("SAVE (ctrl+s) pressed from ", gconf.stateId);
+                    if (grid && abuttons.save) {
+						// Check that we have a Save button before triggering
+						// Saves on a 404 AJAX error when we save an unchanged store
+						// This simply relies on the store to know if it's been changed,
+						// which is what scopes in the Undo button anyway.                        
+						if (!abuttons.save.disabled) abuttons.save.handler();
+                        }
+                    }
+            } , {
+                key: 'z',
+                ctrl: true,
+                stopEvent: true,
+                fn: function() {
+                    console.log("UNDO (ctrl+z) pressed from ", gconf.stateId);
+                    if (grid && abuttons.undo) {
+						// Check that we have an Undo button before triggering
+						// Saves on a 404 AJAX error when we save an unchanged store
+						// As 'Save', this simply relies on the store to know if it's been changed,
+						// which is what scopes in the Undo button anyway.
+                        if (!abuttons.undo.disabled) abuttons.undo.handler();
+                        }
+                    }
+            } , {
+                key: Ext.EventObject.DELETE,
+                stopEvent: true,
+                fn: function() {
+                    console.log("DEL pressed from ", gconf.stateId);
+                    // We always have a Delete button
+                    if (grid && abuttons.del) abuttons.del.handler();
+                    }
+            } , {
+                key: Ext.EventObject.INSERT,
+                stopEvent: true,
+                fn: function() {
+                    console.log("INS pressed from ", gconf.stateId);
+                    // We always have an Add button
+                    if (grid && abuttons.add) abuttons.add.handler();
+                    }
+                }
+            ]);
+
         var gconf = {
             stateful: true,
             stateId: conf.gridURL || conf.url,
@@ -1609,14 +1701,7 @@ tvheadend.idnode_grid = function(panel, conf)
             viewConfig: {
                 forceFit: true
             },
-            keys: {
-                key: 'a',
-                ctrl: true,
-                stopEvent: true,
-                handler: function() {
-                    grid.getSelectionModel().selectAll();
-                }
-            },
+            keys: keymap,
             tbar: buttons,
             bbar: page
         };


### PR DESCRIPTION
_REQUIRES REVIEW/MODIFICATION. **DO NOT MERGE**._

I'm not happy about this - but, in my defence, I don't know what I'm doing :)

This adds:
1. Alt + p == Shifts focus to Paging Toolbar to allow grid paging (see below) 
2. Insert == Add a record
3. Delete == Delete the currently-selected record(s)
4. F2 == Edit the currently-selected record(s) (Excel-style shortcut)
5. Ctrl + e == Edit (as F2)
6. Ctrl + s == Saves any changed record(s)
7. Ctrl + z == Undo any changes to record(s)

(8. Ctrl + a == Selects displayed record(s) - implemented previously)

This seems to (mostly) work, but it feels ugly and is buggy. All debugging statements left in.

**Issues I can see:**
1. The grids already use PgUp/PgDn _within the displayed page_, so we can't (shouldn't) interfere with these. For example, if you have a scrolling page (maybe 100 items) then PgUp/PgDn moves through it, not forwards/backwards a page. Similarly, Home/End move to the top and bottom of the displayed page, not to the top/bottom of the store.
   
   However, these keys do work if the focus is on the TextBox in the Paging Toolbar (where you'd type a new page number). So I've implemented this as a shift-focus keystroke instead of over-riding the keys: Alt+p moves focus to this text box, and then PgUp/PgDn changes page, with Home and End moving to the first and last page respectively.
2. The way that the tabbed panel works is that a key event passes through all the tabs in turn until it reaches the active one. So, a keystroke in "Failed Recordings" triggers three events: one for Upcoming, one for Finished, and a final one when arriving at Failed. So we need to find a way to limit processing to the current (active) tab.
   
   I've done this by simply checking to see that a grid is rendered in the panel, as it will only be rendered in the active one.
3. Save/Undo only make sense if there's something to Save or Undo, so I've tested to see if these buttons have been scoped in (enabled) before triggering the appropriate handler. That leaves the grid to decide if anything has changed, rather than checking again.
4. The same logic should probably hold to the other buttons - Add, Delete. They're normally there, but you can't guaranteed this.

However, there are some serious bugs:
1. It's a global keymap, so these keystrokes apply everywhere. They should be limited to the DVR screens, or otherwise to tabs that make sense (e.g. this will intercept DEL on any text field, which is utter rubbish - you go to erase, say, the server name in Configuration -> General and it fires a deletion event associated with a non-existent Button). 
   
   This highlights that the button check (if !button.disabled) doesn't work. Something in the way the tabs are organised means that _somewhere_ this button is enabled once something has changed, so this test passes. It has to be limited to the active/displayed tab.
   
   A better way might be to simply have the key bindings on the Button objects, but I don't know that's possible. ExtJS 3.4 seems to have overlooked keyboard input for the most part.
2. There seems to be an issue with "once selected, always selected". So, if you select an item in Upcoming Recordings, press F2 to Edit, dismiss, then tab away to, say, "Failed", then F2 no longer does anything - which is correct, as there's no selected record to Edit.
   
   **However**, if you go back to Upcoming and press F2 again then the previously-selected record will pop up, even if no rows are selected... if you select a new row, then F2 will pop up a dialog for both of them. This will repeat for every row you select, so something's remembering the selection.
   
   ==> **this has serious implications for 'Delete' if that would erase any and all previously-selected records on a tab**
